### PR TITLE
Fix frontend results

### DIFF
--- a/backend/flaskApp/search_server.py
+++ b/backend/flaskApp/search_server.py
@@ -1,6 +1,5 @@
 from flask import Flask, request
 app = Flask(__name__, static_url_path='')
-import json
 import sys
 
 
@@ -15,8 +14,8 @@ def getsearch():
 def getallposts():
     return app.searcher.getAllPosts()
 
-def server(config):
-    app.searcher = Searcher(config)
+def server():
+    app.searcher = Searcher()
     return app
 
 if __name__ == '__main__':
@@ -24,4 +23,4 @@ if __name__ == '__main__':
         print("Usage: {} config.toml".format(sys.argv[0]))
         sys.exit(1)
 
-    server(sys.argv[1]).run(host="0.0.0.0", debug=True)
+    server().run(host="0.0.0.0", debug=True)

--- a/backend/flaskApp/searcher.py
+++ b/backend/flaskApp/searcher.py
@@ -47,8 +47,7 @@ class Searcher:
 
         # Only keep letters, numbers, spaces. TODO Handle MATH Mode (stuff in double $$)
         for i, doc in enumerate(corpus):
-            new_str = re.sub("[^0-9a-zA-Z\s]", "", doc)
-            print(new_str)
+            new_str = re.sub("[^0-9a-zA-Z\s\-]", "", doc)
             corpus[i] = new_str
 
         # Remove stopwords

--- a/client/src/jsx/FocusedPost.js
+++ b/client/src/jsx/FocusedPost.js
@@ -30,8 +30,8 @@ function Markdown({children}) {
  * But I'll just use the mock data for the moment.
  */
 export default function FocusedPost() {
-  const {expandedPost, postInfo} = useSelector((state) => state.mem);
-  if (expandedPost === -1) {
+  const {expandedPost} = useSelector((state) => state.mem);
+  if (expandedPost === null) {
     return (
       <FocusedPostContent>
         <FocusedPostCard className='initial-message'>
@@ -41,20 +41,20 @@ export default function FocusedPost() {
     )
   }
 
-  const post = postInfo[expandedPost];
+  console.log(expandedPost);
   return (
     <FocusedPostContent>
       <FocusedPostCard>
-        <p className="primary">{post.post.title}</p>
+        <p className="primary">{expandedPost.post.title}</p>
         <div className="content">
-          <Markdown>{post.post.body}</Markdown>
+          <Markdown>{expandedPost.post.body}</Markdown>
         </div>
       </FocusedPostCard>
       <FocusedPostCard>
         <p className="primary">Responses/Comments</p>
         <div className="content">
           {
-            post.comments.map(({body, id}) => {
+            expandedPost.comments.map(({body, id}) => {
               return <Markdown key={id}>{body}</Markdown>
             })
           }

--- a/client/src/jsx/PostList.js
+++ b/client/src/jsx/PostList.js
@@ -5,17 +5,20 @@ import {
   Divider,
   TextField,
   InputAdornment,
+  IconButton
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useSelector, useDispatch } from "react-redux";
 import { updateQuery, selectPost, sentFetchPosts, gotPosts } from 'redux/memSlice';
 import Loading from 'jsx/Loading';
 import { BACKEND_DOMAIN } from 'api';
+import CancelIcon from '@mui/icons-material/Cancel';
 
-function PostSummary({id: postId, title, body}) {
+function PostSummary({ post }) {
   const dispatch = useDispatch();
+  const {title, body} = post.post;
   return (
-    <ListItem button className="post-summary" onClick={() => dispatch(selectPost(postId))}>
+    <ListItem button className="post-summary" onClick={() => dispatch(selectPost(post))}>
       <div className="list-item-text">
         <p className="primary">{title}</p>
         <p className="secondary">{body}</p>
@@ -26,23 +29,36 @@ function PostSummary({id: postId, title, body}) {
 
 export default function PostList() {
   const dispatch = useDispatch();
-  const { query, postInfo, isLoadingPostInfo } = useSelector((store) => store.mem)
+  const { query, lastFetchedQuery, postInfo, isLoadingPostInfo } = useSelector((store) => store.mem)
   function handleChange(e) {
     const text = e.target.value;
     dispatch(updateQuery(text));
   }
   function handleSubmit(e) {
     e.preventDefault();
-    sentFetchPosts();
-    console.log('fetch')
-    const promise = fetch(`http://${BACKEND_DOMAIN}/results?query=${query}`)
+    if (lastFetchedQuery === query) {
+      return;
+    }
+    dispatch(sentFetchPosts());
 
-    promise.then((res) => {
-      return res.json();
-    }).then((res) => {
+    fetch(`http://${BACKEND_DOMAIN}/results?query=${query}`)
+    .then(res =>  res.json())
+    .then(res => {
       dispatch(gotPosts(res));
     });
-    
+  }
+  function cancelQuery(e) {
+    e.preventDefault();
+    if (query === '') {
+      return '';
+    }
+    dispatch(updateQuery(''));
+    dispatch(sentFetchPosts());
+    fetch(`http://${BACKEND_DOMAIN}/allposts`)
+    .then(res => res.json())
+    .then(res => {
+      dispatch(gotPosts(res));
+    })
   }
   return (
     <div className="post-list-container">
@@ -62,6 +78,13 @@ export default function PostList() {
                 <SearchIcon />
               </InputAdornment>
             ),
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton onClick={cancelQuery}>
+                  <CancelIcon />
+                </IconButton>
+              </InputAdornment>
+            )
           }}
           variant="standard"
         />
@@ -73,9 +96,10 @@ export default function PostList() {
         ? <Loading />
         : postInfo.map((post, index) => {
             const isLast = index === postInfo.length-1;
+            console.log(post);
             return (
-              <React.Fragment key={index}>
-                <PostSummary {...post.post}/>
+              <React.Fragment key={post.id}>
+                <PostSummary post={post}/>
                 {isLast ? null : <Divider component="li" />}
               </React.Fragment>
             )

--- a/client/src/redux/memSlice.js
+++ b/client/src/redux/memSlice.js
@@ -26,9 +26,10 @@ const memSlice = createSlice({
   name: 'mem',
   initialState: {
     query: '',
+    lastFetchedQuery: '',
     postInfo: [],
     isLoadingPostInfo: true,
-    expandedPost: -1,
+    expandedPost: null,
   },
   reducers: {
     updateQuery: (state, action) => {
@@ -39,20 +40,25 @@ const memSlice = createSlice({
     },
     sentFetchPosts: (state) => {
       state.hasLoadedPostInfo = true;
+      state.lastFetchedQuery = state.query;
     },
     gotPosts: (state, action) => {
       state.isLoadingPostInfo = false;
-      
       action.payload.forEach((post, index) => {
+        post.id = index
         post.comments = post.comments.map((comment, index) => {
           return {
             body: comment,
             id: index,
           }
         })
-        post.post.id = index
       });
       state.postInfo = action.payload;
+    },
+    cancelQuery: (state, action) => {
+      state.query = '';
+      state.lastFetchedQuery = '';
+
     }
   }
 })


### PR DESCRIPTION
There was an issue with the `expandedPost` where, because I was using an index into `postInfo`, when the results were updated by a query, the expanded post would also update. This change would disable that interaction (i.e. when a user makes a query, the expandedPost is left alone)